### PR TITLE
Campaign locations

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -34,15 +34,28 @@ class LocationsController < ApplicationController
     @location = Location.find_or_initialize_by(location_params)
     login_redirect
     if current_user?(@campaign.leader)
-      if @location.save
-        flash[:success] = "You've successfully created a location!"
-        @campaign.location = @location
-        @campaign.save
-        redirect_to new_campaign_quest_path(@campaign)
+      if @campaign.location.present?
+        if @location.save
+          flash[:success] = "You've successfully created a location!"
+          @campaign.location = @location
+          @campaign.save
+          redirect_to @campaign
+        else
+          @errors = @location.errors.full_messages
+          flash[:danger] = "Oops! We couldn't create your location!"
+          render 'new'
+        end
       else
-        @errors = @location.errors.full_messages
-        flash[:danger] = "Oops! We couldn't create your location!"
-        render 'new'
+        if @location.save
+          flash[:success] = "You've successfully created a location!"
+          @campaign.location = @location
+          @campaign.save
+          redirect_to new_campaign_quest_path(@campaign)
+        else
+          @errors = @location.errors.full_messages
+          flash[:danger] = "Oops! We couldn't create your location!"
+          render 'new'
+        end
       end
     else
       redirect_to @campaign

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -1,41 +1,51 @@
 class LocationsController < ApplicationController
 
-   before_action :current_user, only: [:create, :new, :edit, :destroy]
-
   def index
     @locations = Location.all
   end
 
   def show
-    @campaign = Campaign.find_by(id: params[:campaign_id])
-    @location = @campaign.location
+    @location = Location.find_by(id: params[:id])
   end
 
   def new
-    if @current_user
-      @campaign = Campaign.find_by(id: params[:campaign_id])
-      if @current_user.id == @campaign.leader_id
-        @location = @campaign.build_location
-      else
-        redirect_to @campaign
-      end
+    login_redirect 
+    @campaign = Campaign.find_by(id: params[:campaign_id])
+    if current_user?(@campaign.leader)
+      @location = @campaign.build_location
     else
-      redirect_to '/login'
+      redirect_to @campaign
     end
+    # ^^^ used the helper methods to simplify code
+    # if @current_user
+    #   @campaign = Campaign.find_by(id: params[:campaign_id])
+    #   if @current_user.id == @campaign.leader_id
+    #     @location = @campaign.build_location
+    #   else
+    #     redirect_to @campaign
+    #   end
+    # else
+    #   redirect_to '/login'
+    # end
   end
 
   def create
     @campaign = Campaign.find_by(id: params[:campaign_id])
     @location = Location.find_or_initialize_by(location_params)
-    if @location.save
-      flash[:success] = "You've successfully created your location!"
-      @campaign.location = @location
-      @campaign.save
-      redirect_to new_campaign_quest_path(@campaign)
+    login_redirect
+    if current_user?(@campaign.leader)
+      if @location.save
+        flash[:success] = "You've successfully created a location!"
+        @campaign.location = @location
+        @campaign.save
+        redirect_to new_campaign_quest_path(@campaign)
+      else
+        @errors = @location.errors.full_messages
+        flash[:danger] = "Oops! We couldn't create your location!"
+        render 'new'
+      end
     else
-      @errors = @location.errors.full_messages
-      flash[:danger] = "Oops! We couldn't create your location!"
-      render 'new'
+      redirect_to @campaign
     end
   end
 

--- a/app/helpers/locations_helper.rb
+++ b/app/helpers/locations_helper.rb
@@ -1,2 +1,7 @@
 module LocationsHelper
+
+  def options_for_state
+    %w(AK AL AR AZ CA CO CT DC DE FL GA HI IA ID IL IN KS KY LA MA MD ME MI MN MO MS MT NC ND NE NH NJ NM NV NY OH OK OR PA RI SC SD TN TX UT VA VT WA WI WV WY)
+  end
+
 end

--- a/app/views/campaigns/show.html.erb
+++ b/app/views/campaigns/show.html.erb
@@ -16,7 +16,10 @@
   <% end %>
   <h2>Location</h2>
       <%= @campaign.location.address %><br>
-      <%= @campaign.location.city %>, <%= @campaign.location.state %>
+      <%= @campaign.location.city %>, <%= @campaign.location.state %><br>
+      <% if current_user?(@campaign.leader) %>
+        <%= link_to "Edit this location", new_campaign_location_path(@campaign) %>
+      <% end %>
   <h2>Quests</h2>
     <ul>
       <% if @quests %>

--- a/app/views/locations/_form.html.erb
+++ b/app/views/locations/_form.html.erb
@@ -12,11 +12,11 @@
 
   <p>
     <%= f.label :state %>
-    <%= f.text_field :state %>
+    <%= f.select :state, options_for_state, prompt: "State" %>
   </p>
 
   <p>
-    <%= f.submit "Create your location!" %>
+    <%= f.submit %>
   </p>
 
 <% end %>

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -1,7 +1,8 @@
+<h1>All locations so far!</h1>
+
 <ul>
   <% @locations.each do |location| %>
-    <li><%= location.address %></li>
-    <li><%= location.city %></li>
-    <li><%= location.state %></li>
+    <li><%= location.address %><br>
+    <%= location.city %>, <%= location.state %></li>
   <% end %>
 </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,8 +7,12 @@ Rails.application.routes.draw do
   get '/logout', to: 'sessions#destroy'
 
   resources :users, path_names: {new: 'signup', create: 'signup'}
+  
   resources :campaigns, except: :index do
-      resources :locations, only: [:index, :show, :create, :new]
+      resources :locations, only: [:create, :new]
       resources :quests, only: [:new, :create, :destroy]
-      end
-   end
+  end
+
+  resources :locations, only: [:index, :show]
+
+end


### PR DESCRIPTION
there is logic now in the location controller

if a location is already present for a campaign, when the location is edited, it does not immediately redirect to add a new quest for that campaign. instead it redirects to the campaign itself. better flow since leader may not want to add any more quests after editing a location
