### PR TITLE
Update index map logic to display markers for recent campaigns

### DIFF
--- a/app/assets/javascripts/index_map.js
+++ b/app/assets/javascripts/index_map.js
@@ -1,6 +1,6 @@
 "use strict"
 
-var indexMap = function(mapDiv, markerArray) {
+var indexMap = function(mapDiv) {
   this.map = new google.maps.Map(mapDiv, {
     center: {lat: 40.72902144999053, lng: -73.99128341814503},
     zoom: 12,
@@ -10,12 +10,12 @@ var indexMap = function(mapDiv, markerArray) {
     streetViewControl: false
   });
   this.geocoder =  new google.maps.Geocoder();
-  this.markerArray = markerArray
+  this.markerArray = []
 };
 
 indexMap.prototype.init = function() {
-  this.addMarkerListener();
-  this.addFindListener();
+  this.addMarkersToMap();
+  // this.addFindListener();
 }
 
 indexMap.prototype.addFindListener = function () {
@@ -29,3 +29,15 @@ indexMap.prototype.addFindListener = function () {
     });
   });
 }
+
+indexMap.prototype.addMarkersToMap = function () {
+  var that = this
+  for (var i = 0; i < locations.length; i++) {
+    var marker = new google.maps.Marker({
+      position: {lat: locations[i].latitude, lng: locations[i].longitude},
+      map: that.map,
+      title: campaigns[i].name
+    });
+    that.markerArray.push(marker)
+  };
+};

--- a/app/assets/javascripts/map.js
+++ b/app/assets/javascripts/map.js
@@ -7,8 +7,8 @@ function initNewMap() {
 }
 
 function initIndexMap() {
-    var recentMarkerArray = []
-    var indexMap = new addLocationMap(document.getElementById( 'index_map' ), recentMarkerArray)
+  var recentMap = new indexMap(document.getElementById( 'index_map' ))
+  recentMap.init();
 }
 
 function updateFields(latLng) {

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -61,27 +61,6 @@ body {
   }
 }
 
-#index {
-  height:100%;
-}
-
-.left-container {
-  display: inline-block;
-  vertical-align: top;
-  height: 100%;
-  width: 48%;
-  padding: 5px;
-}
-.right-container {
-  display: inline-block;
-  vertical-align: top;
-  width: 48%;
-  padding: 5px;
-  p {
-    font-size: 1.4em
-  }
-}
-
 #logo {
   font-weight: 600;
   font-size: 2.4em;

--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -1,6 +1,11 @@
 <% content_for :head do %>
   <%= javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=AIzaSyCZdeZHwH56fPgr1Ray067LcQi1U9SXzTs&callback=initIndexMap&libraries=places", async:true, defer:true %>
 <% end %>
+
+<%= javascript_tag do %>
+  var campaigns = <%= @campaigns.to_json.html_safe %>
+  var locations = <%= @campaigns.map { |campaign| campaign.location }.to_json.html_safe %>
+<% end %>
 <div class="container">
   <div class="row">
     <div class="col-md-6">


### PR DESCRIPTION
The map logic on the main page has been updated to drop markers for the 5 most recently created campaigns. Removed some redundant styles on main stylesheet.
